### PR TITLE
feat: edit existing tasks

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,9 +80,9 @@ func (t Task) Description() string {
 /* MAIN MODEL */
 
 type Model struct {
-	loaded   bool
-	focused  status
-	lists    []list.Model
+	loaded       bool
+	focused      status
+	lists        []list.Model
 	quitting     bool
 	editingIndex int
 }

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			editForm.title.SetValue(task.title)
 			editForm.description.SetValue(task.description)
 			m.editingIndex = list.Index()
-			models[model] = m // save the state of the current model
+			models[board] = m // save the state of the current model
 			models[form] = editForm
 			return models[form].Update(nil)
 		case "d":


### PR DESCRIPTION
Hi, I added the edit feature

Press **e** to edit an existing entry

Algorithm:

1. User presses "e" on a task
2. Save selected task index in model
3. Create new form 
4. Fill title and description using selected task
5. Run form model and wait for Task tea.Msg
6. Do we have saved a task index? (See step 2)
- Yes: Replace existing task with new one
- No: It's a new task --> add to list end


Have fun trying it out!