### PR TITLE
Update module path to GitHub URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module kancli
+module github.com/charmbracelet/kancli
 
 go 1.19
 


### PR DESCRIPTION
Fixes #17 
Changed the module path in go.mod to reflect the GitHub repository URL. This ensures proper dependency management and module resolution.