### PR TITLE
Fix typo in help

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -58,7 +58,7 @@ var keys = keyMap{
 	),
 	Left: key.NewBinding(
 		key.WithKeys("left", "h"),
-		key.WithHelp("←/l", "move left"),
+		key.WithHelp("←/h", "move left"),
 	),
 	Enter: key.NewBinding(
 		key.WithKeys("enter"),


### PR DESCRIPTION
Fix a typo in help (`h` stands for left)